### PR TITLE
Fix deprecated Twig internal function calls

### DIFF
--- a/src/Twig/ArrayExtension.php
+++ b/src/Twig/ArrayExtension.php
@@ -14,6 +14,7 @@ use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
+use Twig\Extension\CoreExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
@@ -89,7 +90,7 @@ final class ArrayExtension extends AbstractExtension
      */
     public function length(Environment $env, $thing)
     {
-        return twig_length_filter($env, $this->getArray($thing));
+        return CoreExtension::lengthFilter($env, $this->getArray($thing));
     }
 
     /**

--- a/src/Twig/ArrayExtension.php
+++ b/src/Twig/ArrayExtension.php
@@ -90,7 +90,8 @@ final class ArrayExtension extends AbstractExtension
      */
     public function length(Environment $env, $thing)
     {
-        return CoreExtension::lengthFilter($env, $this->getArray($thing));
+        $coreExtension = $env->getExtension(CoreExtension::class);
+        return $coreExtension->lengthFilter($env, $this->getArray($thing));
     }
 
     /**

--- a/src/Twig/ArrayExtension.php
+++ b/src/Twig/ArrayExtension.php
@@ -90,8 +90,7 @@ final class ArrayExtension extends AbstractExtension
      */
     public function length(Environment $env, $thing)
     {
-        $coreExtension = $env->getExtension(CoreExtension::class);
-        return $coreExtension->lengthFilter($env, $this->getArray($thing));
+        return CoreExtension::length($env->getCharset(), $this->getArray($thing));
     }
 
     /**

--- a/src/Twig/FieldExtension.php
+++ b/src/Twig/FieldExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\Finder\SplFileInfo;
 use Tightenco\Collect\Support\Collection;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
+use Twig\Extension\CoreExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
@@ -86,7 +87,7 @@ class FieldExtension extends AbstractExtension
             $timezone = $this->config->get('general/timezone', null);
         }
 
-        return twig_date_format_filter($twig, $date, $format, $timezone);
+        return CoreExtension::formatDate($twig, $date, $format, $timezone);
     }
 
     public function fieldFactory(string $name, $definition = null): Field


### PR DESCRIPTION
- Replace twig_length_filter with CoreExtension::lengthFilter
- Replace twig_date_format_filter with CoreExtension::formatDate
- Add CoreExtension use statements
- Resolves 2,679 deprecation warnings from Twig 3.9+